### PR TITLE
geonode-exchange install with PIP

### DIFF
--- a/SOURCES/exchange/exchange-settings.sh
+++ b/SOURCES/exchange/exchange-settings.sh
@@ -2,8 +2,11 @@
 
 set -e
 
-export PATH='/usr/pgsql-9.6/bin':$PATH
-export SITE_URL='http://localhost/'
+if [[ $PATH != *"pgsql-9.6"* ]];then
+  export PATH=$PATH:/usr/pgsql-9.6/bin
+fi
+
+export SITEURL='http://localhost/'
 export ES_URL='http://localhost:9200/'
 export LOCKDOWN_GEONODE=True
 export BROKER_URL='amqp://guest:guest@localhost:5672/'
@@ -14,6 +17,17 @@ export GEOSERVER_DATA_DIR='/opt/geonode/geoserver_data'
 export GEOSERVER_LOG='/opt/geonode/geoserver_data/logs/geoserver.log'
 export GEOGIG_DATASTORE_DIR='/opt/geonode/geoserver_data/geogig'
 export DJANGO_LOG_LEVEL='ERROR'
+export STATIC_ROOT='/opt/boundless/exchange/.storage/static_root'
+export STATIC_URL='/static/'
+export MEDIA_ROOT='/opt/boundless/exchange/.storage/media'
+export MEDIA_URL='/media/'
+export DEBUG_STATIC=False
+export ALLOWED_HOSTS="['*']"
+export LANGUAGE_CODE='en-us'
+export SOCIAL_BUTTONS=False
+export SECRET_KEY='exchange@q(6+mnr&=jb@z#)e_cix10b497vzaav61=de5@m3ewcj9%ctc'
+export DEFAULT_ANONYMOUS_VIEW_PERMISSION=False
+export DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION=False
 # export WGS84_MAP_CRS=True
 # export AUTH_LDAP_SERVER_URI=
 # export LDAP_SEARCH_DN=
@@ -21,3 +35,5 @@ export DJANGO_LOG_LEVEL='ERROR'
 # export AUTH_LDAP_BIND_DN=
 # export AUTH_LDAP_BIND_PASSWORD=
 # export REGISTRYURL=
+
+set +e

--- a/SOURCES/exchange/settings.py
+++ b/SOURCES/exchange/settings.py
@@ -21,25 +21,10 @@
 import os
 from exchange.settings import *  # noqa
 
-
-ALLOWED_HOSTS = ['*']
-DEBUG = False
-SECRET_KEY = 'exchange@q(6+mnr&=jb@z#)e_cix10b497vzaav61=de5@m3ewcj9%ctc'
-
 WSGI_APPLICATION = "exchange.wsgi.application"
 ROOT_URLCONF = 'exchange.urls'
 
 LOCAL_ROOT = os.path.abspath(os.path.dirname(__file__))
-PROJECT_ROOT = os.path.join(LOCAL_ROOT, os.pardir)
-
-# static files storage
-STATICFILES_DIRS.append(os.path.join(LOCAL_ROOT, "static"),)  # noqa
-STATIC_ROOT = os.path.join(PROJECT_ROOT, '.storage/static')
-STATIC_URL = '/static/'
-
-# media file storage
-MEDIA_ROOT = os.path.join(PROJECT_ROOT, '.storage/media')
-MEDIA_URL = '/uploaded/'
 
 # installed applications
 INSTALLED_APPS = (

--- a/SPECS/exchange.spec
+++ b/SPECS/exchange.spec
@@ -137,12 +137,11 @@ python -m pip --version
 python -m pip install pip==8.1.2 --upgrade
 %endif
 
-curl -O https://raw.githubusercontent.com/boundlessgeo/exchange/%{branch}/requirements/prod.txt
-curl -O https://raw.githubusercontent.com/boundlessgeo/exchange/%{branch}/requirements/common.txt
-python -m pip install -r prod.txt
-# total hotfix, need to address upstream
-python -m pip install celery==3.1.18 --upgrade
-rm -f {prod.txt,common.txt}
+# Install requiremtns from specifc commit
+python -m pip install -r https://raw.githubusercontent.com/boundlessgeo/exchange/%{branch}/requirements.txt
+# Install requiremtns from specifc commit
+python -m pip install git+git://github.com/boundlessgeo/exchange.git@%{branch}#egg=geonode-exchange
+
 popd
 
 # setup supervisord configuration


### PR DESCRIPTION
Installs/packages geonode-exchange using pip based on branch/commit passed during a build. Depends on https://github.com/boundlessgeo/exchange/pull/128

Remove duplicate settings that already exist in upstream (see https://github.com/boundlessgeo/exchange/pull/123) 
