### PR TITLE
Update exchange-config to use $STATIC_ROOT

### DIFF
--- a/SOURCES/exchange/exchange-config
+++ b/SOURCES/exchange/exchange-config
@@ -79,8 +79,8 @@ django()
   $PYTHON27 $MANAGE loaddata base_resources
   $PYTHON27 $MANAGE migrate account --noinput
   $PYTHON27 $MANAGE collectstatic --noinput
-  chmod 755 -R /opt/boundless/exchange/.storage
-  chown exchange:geoservice -R /opt/boundless/exchange/.storage
+  chmod 755 -R $STATIC_ROOT
+  chown exchange:geoservice -R $STATIC_ROOT
 }
 
 # configure exchange with selinux

--- a/SOURCES/registry/registry-settings.sh
+++ b/SOURCES/registry/registry-settings.sh
@@ -6,12 +6,12 @@ if [[ $PATH != *"pgsql-9.6"* ]];then
   export PATH=$PATH:/usr/pgsql-9.6/bin
 fi
 
-export REGISTRY_DEBUG=True
-export REGISTRY_SECRET_KEY='Make sure you create a good secret key.'
-export REGISTRY_MAPPING_PRECISION='500m'
-export REGISTRY_SEARCH_URL='http://127.0.0.1:9200'
-export REGISTRY_DATABASE_URL='sqlite:////tmp/registry.db'
-export MAPPROXY_CACHE_DIR='/tmp'
-export REGISTRY_ALLOWED_IPS='*'
+export REGISTRY_DEBUG=${REGISTRY_DEBUG:-'True'}
+export REGISTRY_SECRET_KEY=${REGISTRY_SECRET_KEY:-'Make sure you create a good secret key.'}
+export REGISTRY_MAPPING_PRECISION=${REGISTRY_MAPPING_PRECISION:-'500m'}
+export REGISTRY_SEARCH_URL=${REGISTRY_SEARCH_URL:-'http://127.0.0.1:9200'}
+export REGISTRY_DATABASE_URL=${REGISTRY_DATABASE_URL:-'sqlite:////tmp/registry.db'}
+export MAPPROXY_CACHE_DIR=${MAPPROXY_CACHE_DIR:-'/tmp'}
+export REGISTRY_ALLOWED_IPS=${REGISTRY_ALLOWED_IPS:-'*'}
 
 set +e


### PR DESCRIPTION
In the django function there is a "python manage.py collectstatic"
followed by a chown and a chmod, previously if a user was using
a custom static directory then the files would be moved to the
custom directory and the default directory would get chown/mod-ed,
leaving the working static directory untouched. This change insures
that the static directory will always be updated appropriately,
regardless of the use of standard/custom directories.