### PR TITLE
Update exchange-config to chown static files correctly

### DIFF
--- a/SOURCES/exchange/exchange-config
+++ b/SOURCES/exchange/exchange-config
@@ -75,7 +75,7 @@ django()
   $PYTHON27 $MANAGE loaddata default_oauth_apps
   $PYTHON27 $MANAGE collectstatic --noinput
   chmod 755 -R $STATIC_ROOT
-  chown apache:geoservice -R $STATIC_ROOT
+  chown exchange:geoservice -R $STATIC_ROOT
 }
 
 # configure exchange with selinux


### PR DESCRIPTION
The apache user only needs r-x access to serve the files
in the static directory, which it gets via the geoservices
group. Giving write access to apache could potentially
allow a security vulnerablility.