### PR TITLE
Add EXCHANGE_LOCAL_URL env var

### DIFF
--- a/SOURCES/exchange/exchange-settings.sh
+++ b/SOURCES/exchange/exchange-settings.sh
@@ -3,7 +3,7 @@
 set -e
 
 export SITEURL=${SITEURL:-'http://localhost/'}
-export EXCHANGE_LOCAL_URL=${EXCHANGE_LOCAL_URL:-'http://localhost/'}
+export EXCHANGE_LOCAL_URL=${EXCHANGE_LOCAL_URL:-'http://localhost:8000/'}
 export ES_URL=${ES_URL:-'http://localhost:9200/'}
 export LOCKDOWN_GEONODE=${LOCKDOWN_GEONODE:-'True'}
 export BROKER_URL=${BROKER_URL:-'amqp://guest:guest@localhost:5672/'}

--- a/SOURCES/exchange/exchange-settings.sh
+++ b/SOURCES/exchange/exchange-settings.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-export SITEURL==${SITEURL:-'http://localhost/'}
+export SITEURL=${SITEURL:-'http://localhost/'}
+export EXCHANGE_LOCAL_URL=${EXCHANGE_LOCAL_URL:-'http://localhost/'}
 export ES_URL=${ES_URL:-'http://localhost:9200/'}
 export LOCKDOWN_GEONODE=${LOCKDOWN_GEONODE:-'True'}
 export BROKER_URL=${BROKER_URL:-'amqp://guest:guest@localhost:5672/'}


### PR DESCRIPTION
PKI needs to be able to internal calls back to the
local Exchange without specifically calling the
public url. This allows for circumvention of the
GeoAxis page when making internal calls.